### PR TITLE
Improvements 202201

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,8 @@ cc = "1.0"
 
 [dev-dependencies]
 proptest = "0.9.2"
+
+[features]
+default = ["nano_libc"]
+nano_libc = []
+

--- a/build.rs
+++ b/build.rs
@@ -23,7 +23,7 @@ use quote::quote;
 extern crate itertools;
 use itertools::Itertools;
 
-const BLACKLIST_ITEMS: &'static [&'static str] = &[
+const BLACKLIST_ITEMS: &[&str] = &[
     "seL4_CPtr",
     "seL4_Word",
     "seL4_Int8",
@@ -37,7 +37,7 @@ const BLACKLIST_ITEMS: &'static [&'static str] = &[
     "seL4_WordBits",
 ];
 
-const BUILD_INCLUDE_DIRS: &'static [&'static str] = &[
+const BUILD_INCLUDE_DIRS: &[&str] = &[
     "libsel4/include",
     "libsel4/autoconf",
     "kernel/gen_config",
@@ -46,7 +46,7 @@ const BUILD_INCLUDE_DIRS: &'static [&'static str] = &[
     "libsel4/sel4_arch_include/$SEL4_ARCH$",
 ];
 
-const KERNEL_INCLUDE_DIRS: &'static [&'static str] = &[
+const KERNEL_INCLUDE_DIRS: &[&str] = &[
     "libsel4/include",
     "libsel4/arch_include/$ARCH$",
     "libsel4/sel4_arch_include/$SEL4_ARCH$",
@@ -263,7 +263,7 @@ fn gen_bitfield_test(bf: &BitfieldType) -> TokenStream {
     let field_name_tuples_code = field_names_in_tens
         .into_iter()
         .map(|chunk| quote! {(#(#chunk),*)});
-    let gen_params_fn_code = if field_names.len() > 0 {
+    let gen_params_fn_code = if !field_names.is_empty() {
         quote! {
             #[allow(unused_parens)]
             fn #gen_params_fn() -> impl Strategy<Value = #param_struct_name> {

--- a/build.rs
+++ b/build.rs
@@ -488,13 +488,15 @@ fn main() {
     );
 
     // Build the libc stubs
-    let mut build = cc::Build::new();
-    build.file("src/nano_libc.c");
-    if config.sel4_config.get("KernelPrinting")
-        == Some(&selfe_config::model::SingleValue::Boolean(true))
-    {
-        build.define("KernelPrinting", None);
-    }
+    if cfg!(feature = "nano_libc") {
+	let mut build = cc::Build::new();
+	build.file("src/nano_libc.c");
+	if config.sel4_config.get("KernelPrinting")
+            == Some(&selfe_config::model::SingleValue::Boolean(true))
+	{
+            build.define("KernelPrinting", None);
+	}
 
-    build.compile("nano_libc");
+	build.compile("nano_libc");
+    }
 }

--- a/selfe-arc/src/build.rs
+++ b/selfe-arc/src/build.rs
@@ -11,11 +11,9 @@ where
 {
     let mut archive = pack::Archive::new();
     for (name, path) in named_files {
-        archive.add_file(name, &path).expect(&format!(
-            "Error adding file {} from path {} to archive",
+        archive.add_file(name, &path).unwrap_or_else(|_| panic!("Error adding file {} from path {} to archive",
             name,
-            path.display()
-        ));
+            path.display()));
     }
 
     // rustc links with gcc; we need ld proper

--- a/selfe-arc/src/layout.rs
+++ b/selfe-arc/src/layout.rs
@@ -21,7 +21,7 @@ mod read {
     use core::convert::TryInto;
 
     pub(super) fn read_u8(buf: &[u8]) -> Result<u8, ReadError> {
-        if buf.len() < 1 {
+        if buf.is_empty() {
             Err(ReadError::BufferTooShort)
         } else {
             Ok(buf[0])

--- a/selfe-arc/src/read.rs
+++ b/selfe-arc/src/read.rs
@@ -27,8 +27,8 @@ impl<'a> Iterator for DirectoryEntryIterator<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.remaining_files > 0 {
-            let entry = DirectoryEntry::read(&self.data);
-            self.remaining_files = self.remaining_files - 1;
+            let entry = DirectoryEntry::read(self.data);
+            self.remaining_files -= 1;
             self.data = &self.data[DirectoryEntry::serialized_size()..];
             Some(entry)
         } else {
@@ -77,7 +77,7 @@ impl<'a> Archive<'a> {
             }
         }
 
-        let dir_entry = dir_entry.ok_or_else(|| ReadError::FileNotFound)?;
+        let dir_entry = dir_entry.ok_or(ReadError::FileNotFound)?;
         let header = self.header()?;
         let data_slice = &self.0[header.data_start as usize..];
         Ok(&data_slice

--- a/selfe-config/src/build_helpers.rs
+++ b/selfe-config/src/build_helpers.rs
@@ -60,7 +60,7 @@ impl BuildEnv {
         let cargo_cfg_target_arch = get_env("CARGO_CFG_TARGET_ARCH");
 
         BuildEnv {
-            cargo_cfg_target_arch: cargo_cfg_target_arch.clone(),
+            cargo_cfg_target_arch,
             cargo_cfg_target_pointer_width: get_env("CARGO_CFG_TARGET_POINTER_WIDTH")
                 .parse()
                 .expect("Could not parse CARGO_CFG_TARGET_POINTER_WIDTH as an unsigned integer"),
@@ -152,7 +152,7 @@ pub fn load_config_from_env_or_default() -> model::contextualized::Contextualize
         sel4_arch,
         profile.is_debug(),
         platform,
-        config_dir.as_ref().map(PathBuf::as_path),
+        config_dir.as_deref(),
     )
     .expect("Error resolving config file")
 }

--- a/selfe-config/src/compilation.rs
+++ b/selfe-config/src/compilation.rs
@@ -173,6 +173,19 @@ pub fn build_sel4(
     config: &model::contextualized::Contextualized,
     build_mode: SeL4BuildMode,
 ) -> SeL4BuildOutcome {
+    if let Some(ref build_dir) = config.build_dir {
+	match build_mode {
+	    SeL4BuildMode::Lib => {
+		return SeL4BuildOutcome::StaticLib {
+		    build_dir: build_dir.to_path_buf()
+		}
+	    },
+	    SeL4BuildMode::Kernel => {
+		panic!("Kernel build not supported when build_dir is provided");
+	    }
+	}
+    }
+
     let cmake_lists_content = match build_mode {
         SeL4BuildMode::Kernel => CMAKELISTS_KERNEL,
         SeL4BuildMode::Lib => CMAKELISTS_LIB,

--- a/selfe-config/src/compilation.rs
+++ b/selfe-config/src/compilation.rs
@@ -250,7 +250,7 @@ pub fn build_sel4(
         .arg("Ninja")
         .arg(".")
         .current_dir(&build_dir)
-        .env("SEL4_TOOLS_DIR", tools_dir.to_owned());
+        .env("SEL4_TOOLS_DIR", tools_dir);
 
     if build_mode == SeL4BuildMode::Kernel {
         let rti = PathBuf::from(

--- a/selfe-config/src/model/deserialization.rs
+++ b/selfe-config/src/model/deserialization.rs
@@ -275,7 +275,7 @@ impl FromStr for full::Full {
 		build_dir: sel4.build_dir,
                 config: structure_property_tree(sel4.config)?,
             },
-            build: build.unwrap_or_else(BTreeMap::new),
+            build: build.unwrap_or_default(),
             metadata: structure_property_tree(metadata)?,
         })
     }
@@ -338,15 +338,15 @@ fn parse_repo_source(table: &TomlTable) -> Result<RepoSource, ImportError> {
         match (branch, tag, rev) {
             (Some(b), None, None) => Ok(RepoSource::RemoteGit {
                 url,
-                target: GitTarget::Branch(b.to_owned()),
+                target: GitTarget::Branch(b),
             }),
             (None, Some(t), None) => Ok(RepoSource::RemoteGit {
                 url,
-                target: GitTarget::Tag(t.to_owned()),
+                target: GitTarget::Tag(t),
             }),
             (None, None, Some(r)) => Ok(RepoSource::RemoteGit {
                 url,
-                target: GitTarget::Rev(r.to_owned()),
+                target: GitTarget::Rev(r),
             }),
             _ => Err(ImportError::MissingProperty {
                 name: "branch or tag or rev".to_string(),
@@ -414,8 +414,8 @@ fn structure_property_tree(
 
     Ok(full::PropertiesTree {
         shared,
-        debug: debug.unwrap_or_else(BTreeMap::new),
-        release: release.unwrap_or_else(BTreeMap::new),
+        debug: debug.unwrap_or_default(),
+        release: release.unwrap_or_default(),
         contextual,
     })
 }

--- a/selfe-config/src/model/deserialization.rs
+++ b/selfe-config/src/model/deserialization.rs
@@ -19,6 +19,7 @@ pub(crate) struct RawSeL4 {
     pub(crate) kernel: TomlTable,
     pub(crate) tools: TomlTable,
     pub(crate) util_libs: TomlTable,
+    pub(crate) build_dir: Option<PathBuf>,
     pub(crate) config: BTreeMap<String, TomlValue>,
 }
 
@@ -83,6 +84,7 @@ impl FromStr for Raw {
             let kernel = parse_required_table(table, "kernel")?;
             let tools = parse_required_table(table, "tools")?;
             let util_libs = parse_required_table(table, "util_libs")?;
+            let build_dir = parse_optional_string(table, "build_dir")?.map(PathBuf::from);
 
             let mut config = BTreeMap::new();
             if let Some(config_val) = table.get("config") {
@@ -102,6 +104,7 @@ impl FromStr for Raw {
                 kernel,
                 tools,
                 util_libs,
+                build_dir,
                 config,
             })
         }
@@ -269,6 +272,7 @@ impl FromStr for full::Full {
         Ok(full::Full {
             sel4: full::SeL4 {
                 sources,
+		build_dir: sel4.build_dir,
                 config: structure_property_tree(sel4.config)?,
             },
             build: build.unwrap_or_else(BTreeMap::new),

--- a/selfe-config/src/model/mod.rs
+++ b/selfe-config/src/model/mod.rs
@@ -225,8 +225,8 @@ impl Display for Arch {
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Platform(pub String);
 impl Display for Platform {
-    fn fmt(&self, mut f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(&mut f)
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 
@@ -420,13 +420,13 @@ pub mod contextualized {
             base_dir: Option<&Path>,
         ) -> Result<Contextualized, ImportError> {
             let context = Context {
-                platform: platform.clone(),
+                platform,
                 arch,
                 sel4_arch,
                 is_debug,
                 base_dir: base_dir.map(Path::to_path_buf),
             };
-            Contextualized::from_full_context(&f, context)
+            Contextualized::from_full_context(f, context)
         }
 
         pub fn from_full_context(

--- a/selfe-config/src/model/mod.rs
+++ b/selfe-config/src/model/mod.rs
@@ -305,6 +305,7 @@ pub mod full {
     #[derive(Debug, Clone, PartialEq)]
     pub struct SeL4 {
         pub sources: SeL4Sources,
+	pub build_dir: Option<PathBuf>,
         pub config: Config,
     }
 
@@ -323,8 +324,8 @@ pub mod full {
     }
 
     impl SeL4 {
-        pub fn new(sources: SeL4Sources, config: Config) -> Self {
-            SeL4 { sources, config }
+        pub fn new(sources: SeL4Sources, build_dir: Option<PathBuf>, config: Config) -> Self {
+            SeL4 { sources, build_dir, config }
         }
     }
 
@@ -368,6 +369,7 @@ pub mod contextualized {
     #[derive(Debug, Clone, PartialEq, Hash)]
     pub struct Contextualized {
         pub sel4_sources: SeL4Sources,
+	pub build_dir: Option<PathBuf>,
         pub context: Context,
         pub sel4_config: BTreeMap<String, SingleValue>,
         pub build: Build,
@@ -487,9 +489,11 @@ pub mod contextualized {
             let metadata = resolve_context(&f.metadata, &context);
 
             let sel4_sources = f.sel4.sources.relative_to(&context.base_dir);
+	    let build_dir = f.sel4.build_dir.clone();
 
             Ok(Contextualized {
                 sel4_sources,
+		build_dir,
                 context,
                 sel4_config,
                 build,
@@ -513,6 +517,7 @@ mod tests {
                         tools: RepoSource::LocalPath(PathBuf::from(".")),
                         util_libs: RepoSource::LocalPath(PathBuf::from(".")),
                     },
+		    build_dir: None,
                     config: Default::default(),
                 },
                 build: Default::default(),

--- a/selfe-config/tests/integration.rs
+++ b/selfe-config/tests/integration.rs
@@ -53,7 +53,7 @@ path = './deps/util_libs'
 fn reads_from_external_default_file_okay() {
     let toml_content = include_str!("../src/default_config.toml");
     let f: full::Full = toml_content.parse().expect("could not read toml");
-    assert!(f.sel4.config.shared.len() > 0);
+    assert!(!f.sel4.config.shared.is_empty());
 }
 
 #[test]
@@ -311,6 +311,6 @@ fn assert_contains_int(map: &BTreeMap<String, SingleValue>, key: &str, val: i64)
     assert_eq!(
         &SingleValue::Integer(val),
         map.get(key)
-            .expect(&format!("Did not contain expected key {}", key))
+            .unwrap_or_else(|| panic!("Did not contain expected key {}", key))
     );
 }

--- a/src/compile_time_assertions.rs
+++ b/src/compile_time_assertions.rs
@@ -321,13 +321,6 @@ mod x86_shared_compile_time_assertions {
     const X86_PAGE_UNMAP: unsafe extern "C" fn(_service: seL4_X86_Page) -> seL4_Error =
         seL4_X86_Page_Unmap;
 
-    const X86_PAGE_REMAP: unsafe extern "C" fn(
-        _service: seL4_X86_Page,
-        vspace: seL4_CPtr,
-        rights: seL4_CapRights,
-        attr: seL4_X86_VMAttributes,
-    ) -> seL4_Error = seL4_X86_Page_Remap;
-
     const X86_PAGE_GETADDRESS: unsafe extern "C" fn(
         _service: seL4_X86_Page,
     ) -> seL4_X86_Page_GetAddress_t = seL4_X86_Page_GetAddress;
@@ -444,12 +437,6 @@ mod arm_specific_compile_time_assertions {
         rights: seL4_CapRights_t,
         attr: seL4_ARM_VMAttributes,
     ) -> seL4_Error = seL4_ARM_Page_Map;
-    const ARM_PAGE_REMAP: unsafe extern "C" fn(
-        _service: seL4_ARM_Page,
-        vspace: seL4_CPtr,
-        rights: seL4_CapRights_t,
-        attr: seL4_ARM_VMAttributes,
-    ) -> seL4_Error = seL4_ARM_Page_Remap;
     const ARM_PAGE_UNIFY_INSTRUCTION: unsafe extern "C" fn(
         _service: seL4_ARM_Page,
         start_offset: seL4_Word,


### PR DESCRIPTION
This PR makes several small improvements to selfs-sys; the most important one is a change to selfe-config that allows the selfe-sys build to use a pre-built seL4 rather than requiring that it be checked out and built under control of Cargo build scripts. (I have prototyped using https://github.com/corrosion-rs/corrosion to build Rust crates alongside seL4 and other code with the seL4 build system.)